### PR TITLE
centos8 version of dev box

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@
   - next, we're git cloning and setting user apache permissions
   - ```sudo git clone https://github.com/lsulibraries/drupal_sync```
   - ```sudo chown -R apache:apache drupal_sync```
-  - ```sudo -u apache chmod -a a+w /var/www/html/drupal_site/drupal_sync```
+  - ```sudo -u apache chmod -R a+w /var/www/html/drupal_site/drupal_sync```
 
 ### Replace theme/contrib with our symlinked repo
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "centos/7"
-  config.vm.box_version = "1905.1" # based on CentOS 7.6.1811
+  config.vm.box = "centos/8"
+  config.vm.box_version = "1905.1"
 
   config.vm.network "forwarded_port", guest: 80, host: 8080
 

--- a/playbooks/dev_build.yml
+++ b/playbooks/dev_build.yml
@@ -29,6 +29,15 @@
       update_cache: yes
       state: latest
 
+  - name: install programs necessary for VirtualBox
+    become: yes
+    yum:
+      name: "{{ item }}"
+      update_cache: yes
+      state: latest
+    with_items:
+      - elfutils-libelf-devel
+
   - name: install programs necessary for remi repo
     become: yes
     yum:
@@ -48,20 +57,19 @@
   - name: fetch remi php repository
     become: yes
     yum:
-      name: https://rpms.remirepo.net/enterprise/remi-release-7.rpm
+      name: https://rpms.remirepo.net/enterprise/remi-release-8.rpm
 
   - name: enable remi php repository
     become: yes
-    shell: yum-config-manager --enable remi-php73
+    shell: dnf module enable php:remi-7.4 -y
 
   - name: install php7
     become: yes
-    yum:
+    dnf:
       name: "{{ item }}"
       update_cache: yes
       state: latest
-      enablerepo: "remi-php73"
-    # timeout: 120
+      enablerepo: "remi-php74"
     with_items:
       - php
       - php-opcache

--- a/playbooks/prod_build.yml
+++ b/playbooks/prod_build.yml
@@ -184,7 +184,7 @@
       executable: /bin/bash
       creates: /var/www/html/drupal_site/drupal_salt.txt
 
-  - name: set drual_salt to apache:apache permissions
+  - name: set drupal_salt to apache:apache permissions
     become: yes
     file:
       path: /var/www/html/drupal_site/drupal_salt.txt


### PR DESCRIPTION
Two spelling mistakes fixed:  Readme & comment in prod_build.yml

Actual changes are:
  - setting Vagrantfile to use CentOS 8 -- like production uses.
  - updating install commands for packages